### PR TITLE
Add support for filtering events

### DIFF
--- a/eventrouter.go
+++ b/eventrouter.go
@@ -20,8 +20,10 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/heptiolabs/eventrouter/sinks"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/heptiolabs/eventrouter/filter"
+	"github.com/heptiolabs/eventrouter/sinks"
 
 	"k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -74,13 +76,17 @@ type EventRouter struct {
 	// event sink
 	// TODO: Determine if we want to support multiple sinks.
 	eSink sinks.EventSinkInterface
+
+	// includeFilter is an include filter that specifies which events to include
+	includeFilter filter.EventIncludeFilter
 }
 
 // NewEventRouter will create a new event router using the input params
-func NewEventRouter(kubeClient kubernetes.Interface, eventsInformer coreinformers.EventInformer) *EventRouter {
+func NewEventRouter(kubeClient kubernetes.Interface, eventsInformer coreinformers.EventInformer, includeFilter filter.EventIncludeFilter) *EventRouter {
 	er := &EventRouter{
-		kubeClient: kubeClient,
-		eSink:      sinks.ManufactureSink(),
+		kubeClient:    kubeClient,
+		eSink:         sinks.ManufactureSink(),
+		includeFilter: includeFilter,
 	}
 	eventsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    er.addEvent,
@@ -97,7 +103,7 @@ func (er *EventRouter) Run(stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer glog.Infof("Shutting down EventRouter")
 
-	glog.Infof("Starting EvenRouter")
+	glog.Infof("Starting EventRouter")
 
 	// here is where we kick the caches into gear
 	if !cache.WaitForCacheSync(stopCh, er.eListerSynched) {
@@ -110,16 +116,20 @@ func (er *EventRouter) Run(stopCh <-chan struct{}) {
 // addEvent is called when an event is created, or during the initial list
 func (er *EventRouter) addEvent(obj interface{}) {
 	e := obj.(*v1.Event)
-	prometheusEvent(e)
-	er.eSink.UpdateEvents(e, nil)
+	if er.includeFilter.Passes(e) {
+		prometheusEvent(e)
+		er.eSink.UpdateEvents(e, nil)
+	}
 }
 
 // updateEvent is called any time there is an update to an existing event
 func (er *EventRouter) updateEvent(objOld interface{}, objNew interface{}) {
 	eOld := objOld.(*v1.Event)
 	eNew := objNew.(*v1.Event)
-	prometheusEvent(eNew)
-	er.eSink.UpdateEvents(eNew, eOld)
+	if er.includeFilter.Passes(eNew) {
+		prometheusEvent(eNew)
+		er.eSink.UpdateEvents(eNew, eOld)
+	}
 }
 
 // prometheusEvent is called when an event is added or updated
@@ -158,5 +168,7 @@ func (er *EventRouter) deleteEvent(obj interface{}) {
 	e := obj.(*v1.Event)
 	// NOTE: This should *only* happen on TTL expiration there
 	// is no reason to push this to a sink
-	glog.V(5).Infof("Event Deleted from the system:\n%v", e)
+	if er.includeFilter.Passes(e) {
+		glog.V(5).Infof("Event Deleted from the system:\n%v", e)
+	}
 }

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -1,0 +1,51 @@
+package filter
+
+import (
+	"k8s.io/api/core/v1"
+)
+
+// EventIncludeFilter filters in events that should be included. Values within
+// a given field are ORed together, while fields themselves are ANDed together.
+// If a given field is empty, then that field allows everything through.
+//
+// For example, to filter in "Pods or DaemonSets with any Name in Namespace "kube-system":
+//    Kind: ["Pod", "DaemonSet"]
+//    Name: []
+//    Namespace: ["kube-system"]
+type EventIncludeFilter struct {
+	Kind      []string `mapstructure:"Kind"`
+	Name      []string `mapstructure:"Name"`
+	Namespace []string `mapstructure:"Namespace"`
+}
+
+// existsInSlice returns true if the given string exists in the slice, else false.
+func existsInSlice(s string, slice []string) bool {
+	for _, v := range slice {
+		if s == v {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Passes returns true if the event is allowed through this filter, else false.
+func (f EventIncludeFilter) Passes(event *v1.Event) bool {
+	if len(f.Kind) > 0 {
+		if !existsInSlice(event.InvolvedObject.Kind, f.Kind) {
+			return false
+		}
+	}
+	if len(f.Name) > 0 {
+		if !existsInSlice(event.InvolvedObject.Name, f.Name) {
+			return false
+		}
+	}
+	if len(f.Namespace) > 0 {
+		if !existsInSlice(event.InvolvedObject.Namespace, f.Namespace) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -1,0 +1,157 @@
+package filter
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+)
+
+type passesFilterTest struct {
+	filter   EventIncludeFilter
+	input    *v1.Event
+	expected bool
+}
+
+var includeAllFilter = EventIncludeFilter{}
+
+var excludeAllFilter = EventIncludeFilter{
+	Kind:      []string{"-"},
+	Name:      []string{"-"},
+	Namespace: []string{"-"},
+}
+
+var podOnlyFilter = EventIncludeFilter{
+	Kind: []string{"Pod"},
+}
+
+var podInDefaultFilter = EventIncludeFilter{
+	Kind:      []string{"Pod"},
+	Namespace: []string{"default"},
+}
+
+var podOrDeploymentInDefaultFilter = EventIncludeFilter{
+	Kind:      []string{"Pod", "Deployment"},
+	Namespace: []string{"default"},
+}
+
+func buildEvent(kind, name, namespace string) *v1.Event {
+	return &v1.Event{
+		InvolvedObject: v1.ObjectReference{
+			Kind:      kind,
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+var includeAllTests = []passesFilterTest{
+	{
+		filter:   includeAllFilter,
+		input:    buildEvent("AnyKind", "AnyName", "AnyNamespace"),
+		expected: true,
+	},
+}
+
+var excludeAllTests = []passesFilterTest{
+	{
+		filter:   excludeAllFilter,
+		input:    buildEvent("AnyKind", "AnyName", "AnyNamespace"),
+		expected: false,
+	},
+}
+
+var miscTests = []passesFilterTest{
+	// Filter in Pods
+	{
+		filter:   podOnlyFilter,
+		input:    buildEvent("Pod", "", ""),
+		expected: true,
+	},
+	{
+		filter:   podOnlyFilter,
+		input:    buildEvent("Pod", "AnyName", ""),
+		expected: true,
+	},
+	{
+		filter:   podOnlyFilter,
+		input:    buildEvent("Pod", "", "AnyNamespace"),
+		expected: true,
+	},
+	{
+		filter:   podOnlyFilter,
+		input:    buildEvent("NotPod", "", ""),
+		expected: false,
+	},
+	{
+		filter:   podOnlyFilter,
+		input:    buildEvent("NotPod", "AnyName", "AnyNamespace"),
+		expected: false,
+	},
+
+	// Filter in Pods in default namespace
+	{
+		filter:   podInDefaultFilter,
+		input:    buildEvent("Pod", "AnyName", "default"),
+		expected: true,
+	},
+	{
+		filter:   podInDefaultFilter,
+		input:    buildEvent("NotPod", "AnyName", "default"),
+		expected: false,
+	},
+	{
+		filter:   podInDefaultFilter,
+		input:    buildEvent("NotPod", "AnyName", "notdefault"),
+		expected: false,
+	},
+
+	// Filter in Pods or Deployments in default namespace
+	{
+		filter:   podOrDeploymentInDefaultFilter,
+		input:    buildEvent("Pod", "AnyName", "default"),
+		expected: true,
+	},
+	{
+		filter:   podOrDeploymentInDefaultFilter,
+		input:    buildEvent("Deployment", "AnyName", "default"),
+		expected: true,
+	},
+	{
+		filter:   podOrDeploymentInDefaultFilter,
+		input:    buildEvent("Neither", "AnyName", "default"),
+		expected: false,
+	},
+}
+
+func testPassesFilterIncludeAll(t *testing.T) {
+	for i, test := range includeAllTests {
+		if res := test.filter.Passes(test.input); res != test.expected {
+			t.Errorf("PassesFilterIncludeall test %d: result = %v, expected = %v\n",
+				i, res, test.expected)
+		}
+	}
+}
+
+func testPassesFilterExcludeAll(t *testing.T) {
+	for i, test := range excludeAllTests {
+		if res := test.filter.Passes(test.input); res != test.expected {
+			t.Errorf("PassesFilterExcludeAll test %d: result = %v, expected = %v\n",
+				i, res, test.expected)
+		}
+	}
+}
+
+func testPassesFilterMisc(t *testing.T) {
+	for i, test := range miscTests {
+		if res := test.filter.Passes(test.input); res != test.expected {
+			t.Errorf("PassesFilterMisc test %d: result = %v, expected = %v\n",
+				i, res, test.expected)
+		}
+	}
+}
+
+func TestPassesFilter(t *testing.T) {
+	t.Run("IncludeAll", testPassesFilterIncludeAll)
+	t.Run("ExcludeAll", testPassesFilterExcludeAll)
+	t.Run("Misc", testPassesFilterMisc)
+}


### PR DESCRIPTION
## Description

This adds support for filtering events based on object Kind, Name, and/or Namespace.

## Testing

- Unit tests in the `filter` package
- Apply various filters via viper config, generate events for filtered-in objects, and see that only those events make it to the sink while others do not (tested with `glog`)

## TODO

This should be good to merge here now (pending reviews) but I'll do a few more things before submitting an upstream PR:

- Update README
- Consider adding support for multiple include filters (should be trivial)