### PR TITLE
Add support for additional HTTP headers

### DIFF
--- a/sinks/httpsink.go
+++ b/sinks/httpsink.go
@@ -53,12 +53,14 @@ type HTTPSink struct {
 	eventCh    channels.Channel
 	httpClient *pester.Client
 	bodyBuf    *bytes.Buffer
+	headers    map[string]string
 }
 
 // NewHTTPSink constructs a new HTTPSink given a sink URL and buffer size
-func NewHTTPSink(sinkURL string, overflow bool, bufferSize int) *HTTPSink {
+func NewHTTPSink(sinkURL string, overflow bool, bufferSize int, headers map[string]string) *HTTPSink {
 	h := &HTTPSink{
 		SinkURL: sinkURL,
+		headers: headers,
 	}
 
 	if overflow {
@@ -147,6 +149,11 @@ func (h *HTTPSink) drainEvents(events []EventData) {
 	if err != nil {
 		glog.Warningf(err.Error())
 		return
+	}
+
+	// Add optional http headers
+	for k, v := range h.headers {
+		req.Header.Set(k, v)
 	}
 
 	resp, err := h.httpClient.Do(req)

--- a/sinks/httpsink_test.go
+++ b/sinks/httpsink_test.go
@@ -71,7 +71,7 @@ func TestUpdateEvents(t *testing.T) {
 	evt := makeFakeEvent(podRef, v1.EventTypeWarning, "CreateInCluster", "Fake pod creation event")
 
 	// 1. Try with a synchronous channel
-	sink := NewHTTPSink(srv.URL, false, 0)
+	sink := NewHTTPSink(srv.URL, false, 0, nil)
 	go func() {
 		sink.Run(stopCh)
 		doneCh <- true
@@ -89,7 +89,7 @@ func TestUpdateEvents(t *testing.T) {
 	// 2. Try with the server returning 500's, test retries
 	got.Truncate(0)
 	seenRequests = make([]*http.Request, 0)
-	sink = NewHTTPSink(srv.URL, false, 10)
+	sink = NewHTTPSink(srv.URL, false, 10, nil)
 
 	go func() {
 		sink.Run(stopCh)
@@ -122,7 +122,7 @@ func TestUpdateEvents(t *testing.T) {
 	numExpected := 10
 	got.Truncate(0)
 	seenRequests = make([]*http.Request, 0)
-	sink = NewHTTPSink(srv.URL, true, numExpected)
+	sink = NewHTTPSink(srv.URL, true, numExpected, nil)
 
 	for i := 0; i < 1000; i++ {
 		evt.Message = "msg " + strconv.Itoa(i)

--- a/sinks/interfaces.go
+++ b/sinks/interfaces.go
@@ -50,11 +50,14 @@ func ManufactureSink() (e EventSinkInterface) {
 		// 1500 have come in without getting consumed
 		viper.SetDefault("httpSinkBufferSize", 1500)
 		viper.SetDefault("httpSinkDiscardMessages", true)
+		// Users can optionally specify HTTP headers to be included in every request
+		viper.SetDefault("httpHeaders", nil)
 
 		bufferSize := viper.GetInt("httpSinkBufferSize")
 		overflow := viper.GetBool("httpSinkDiscardMessages")
+		headers := viper.GetStringMapString("httpHeaders")
 
-		h := NewHTTPSink(url, overflow, bufferSize)
+		h := NewHTTPSink(url, overflow, bufferSize, headers)
 		go h.Run(make(chan bool))
 		return h
 	case "kafka":


### PR DESCRIPTION
## Description

This adds support for additional HTTP headers for HTTP sinks. They're provided in the json config as, for example:

```
"httpHeaders": {
    "Authorization": "<auth value here>"
}
```

## Testing

Made authorized requests with headers appended using the new config and saw that they worked.

## TODO

We can merge this here but I'm considering some further changes before submitting upstream if we decide to do that:

- Unit tests
- Update README